### PR TITLE
fix the Get method of Client

### DIFF
--- a/rest.go
+++ b/rest.go
@@ -22,7 +22,8 @@ func (c *Client) Get(url string, p *napping.Params, results interface{}) (*nappi
 	fullUrl := c.makeFullUrl(url)
 	var errMsg errorResponse
 	c.Log("Sending GET request to %s", fullUrl)
-	res, err := c.session.Get(c.makeFullUrl(url), p, results, &errMsg)
+	params := p.AsUrlValues()
+	res, err := c.session.Get(fullUrl, &params, results, &errMsg)
 	return c.checkNappingError(res, err, errMsg)
 }
 


### PR DESCRIPTION
The Session.Get method from the napping library expects url.Values for params, but napping.Params were passed. This resulted errors when building.
